### PR TITLE
refactor: remove deprecated method

### DIFF
--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -143,14 +143,6 @@ class CopilotPlugin(NpmClientHandler):
             return "unknown"
 
     @classmethod
-    def minimum_node_version(cls) -> Tuple[int, int, int]:
-        """
-        @todo Deprecated.
-        @see https://github.com/sublimelsp/lsp_utils/pull/93
-        """
-        return (16, 0, 0)
-
-    @classmethod
     def required_node_version(cls) -> str:
         """
         Testing playground at https://semver.npmjs.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 
 autoflake
 black
-flake8
+flake8==5.*
 isort
 mypy


### PR DESCRIPTION
It has been more than a month since last `lsp_utils` release so I guess it's safe to remove deprecated `minimum_node_version` (it has been replaced by `required_node_version`).