### PR TITLE
revert: "chore: bump server to 1.8.1 (#76)"

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,24 +1,25 @@
 {
     "name": "language-server",
+    "version": "c2e75a3a7519c126c6fdb35984976df9ae13f564a",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "copilot-node-server": "^1.8.1"
+                "copilot-node-server": "^1.8.0"
             }
         },
         "node_modules/copilot-node-server": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.1.tgz",
-            "integrity": "sha512-HqNt1f+pO/WkGrOE9MaMYRaQc4tTqAtENR2YB7zNLmGl0wmAxYnPZWVx5grjCY+g0m/HkAkwxMVDGtHtx5vBeQ=="
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.0.tgz",
+            "integrity": "sha512-2LnDdRVQzNZ6w/4LjsU7xoBZBbuccZoLTK3wKJDCaDNQaUi1h2G1u9rhFQT7P9+jguP5LvyfzXql3K0y55Ku6w=="
         }
     },
     "dependencies": {
         "copilot-node-server": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.1.tgz",
-            "integrity": "sha512-HqNt1f+pO/WkGrOE9MaMYRaQc4tTqAtENR2YB7zNLmGl0wmAxYnPZWVx5grjCY+g0m/HkAkwxMVDGtHtx5vBeQ=="
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.0.tgz",
+            "integrity": "sha512-2LnDdRVQzNZ6w/4LjsU7xoBZBbuccZoLTK3wKJDCaDNQaUi1h2G1u9rhFQT7P9+jguP5LvyfzXql3K0y55Ku6w=="
         }
     }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "copilot-node-server": "^1.8.1"
+        "copilot-node-server": "^1.8.0"
     }
 }


### PR DESCRIPTION
This reverts commit 2ad4d660b2679fad69c1d5b57e4d7d38274cdbf0.

As a temporary workaround for https://github.com/TerminalFi/LSP-copilot/issues/77 and we can then investigate what further change should be taken when we are available. 

p.s. v1.8.0 works fine but v1.8.1 is broken.

Emergency tag @timfjord @TerminalFi for approval.