### PR TITLE
fix: Invalid params: /doc must have required property 'version'

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -6,20 +6,20 @@
     "packages": {
         "": {
             "dependencies": {
-                "copilot-node-server": "^1.8.0"
+                "copilot-node-server": "^1.8.1"
             }
         },
         "node_modules/copilot-node-server": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.0.tgz",
-            "integrity": "sha512-2LnDdRVQzNZ6w/4LjsU7xoBZBbuccZoLTK3wKJDCaDNQaUi1h2G1u9rhFQT7P9+jguP5LvyfzXql3K0y55Ku6w=="
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.1.tgz",
+            "integrity": "sha512-HqNt1f+pO/WkGrOE9MaMYRaQc4tTqAtENR2YB7zNLmGl0wmAxYnPZWVx5grjCY+g0m/HkAkwxMVDGtHtx5vBeQ=="
         }
     },
     "dependencies": {
         "copilot-node-server": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.0.tgz",
-            "integrity": "sha512-2LnDdRVQzNZ6w/4LjsU7xoBZBbuccZoLTK3wKJDCaDNQaUi1h2G1u9rhFQT7P9+jguP5LvyfzXql3K0y55Ku6w=="
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.8.1.tgz",
+            "integrity": "sha512-HqNt1f+pO/WkGrOE9MaMYRaQc4tTqAtENR2YB7zNLmGl0wmAxYnPZWVx5grjCY+g0m/HkAkwxMVDGtHtx5vBeQ=="
         }
     }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "copilot-node-server": "^1.8.0"
+        "copilot-node-server": "^1.8.1"
     }
 }

--- a/plugin/ui/completion.py
+++ b/plugin/ui/completion.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 
 import mdpopups
 import sublime
-from LSP.plugin.core.typing import Dict, List, Optional, Sequence, Type, Union
+from LSP.plugin.core.typing import List, Optional, Sequence, Type, Union
 
 from ..types import CopilotPayloadCompletion
 from ..utils import (

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -191,6 +191,10 @@ def prepare_completion_request(view: sublime.View) -> Optional[Dict[str, Any]]:
             "relativePath": get_project_relative_path(file_path),
             "languageId": get_view_language_id(view),
             "position": {"line": row, "character": col},
+            
+            # Buffer Version. Generally this is handled by LSP, but we need to handle it here 
+            # Will need to test getting the version from LSP
+            "version": 0
         }
     }
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -10,7 +10,7 @@ import mdpopups
 import sublime
 from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.types import basescope2languageid
-from LSP.plugin.core.typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, TypeVar, Union, cast
+from LSP.plugin.core.typing import Any, Callable, Dict, Generator, Iterable, List, Optional, TypeVar, Union, cast
 from LSP.plugin.core.url import filename_to_uri
 
 from .constants import COPILOT_VIEW_SETTINGS_PREFIX, PACKAGE_NAME
@@ -191,10 +191,9 @@ def prepare_completion_request(view: sublime.View) -> Optional[Dict[str, Any]]:
             "relativePath": get_project_relative_path(file_path),
             "languageId": get_view_language_id(view),
             "position": {"line": row, "character": col},
-            
-            # Buffer Version. Generally this is handled by LSP, but we need to handle it here 
+            # Buffer Version. Generally this is handled by LSP, but we need to handle it here
             # Will need to test getting the version from LSP
-            "version": 0
+            "version": 0,
         }
     }
 


### PR DESCRIPTION
Copilot now requests that the `doc` parameter now contains `version` with the document version. This must match what is on the server side as well. 

For now, using value of 0 seems to work, however the best scenario would be to try and get the `version` from LSP as it tracks it for us