### PR TITLE
feat: add HTTP proxy support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,11 @@ indent_size = 4
 [sublime-package.json]
 indent_size = 2
 
-[*.{sublime-commands,sublime-keymap,sublime-menu,sublime-mousemap,sublime-settings}]
+[*.{sublime-commands,sublime-keymap,sublime-menu,sublime-mousemap}]
+indent_size = 4
+
+[*.sublime-settings]
+indent_style = tab
 indent_size = 4
 
 [*.sublime-syntax]

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -15,6 +15,7 @@
 		"hook_to_auto_complete_command": false,
 		"local_checks": false,
 		"telemetry": false,
+		"proxy": "",
 		"completion_style": "popup"
 	},
 	// ST4 configuration

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -23,6 +23,18 @@ StLayout = TypedDict(
     total=True,
 )
 
+NetworkProxy = TypedDict(
+    "NetworkProxy",
+    {
+        "host": str,
+        "port": int,
+        "username": str,
+        "password": str,
+        "rejectUnauthorized": bool,
+    },
+    total=True,
+)
+
 # --------------- #
 # Copilot payload #
 # --------------- #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,8 @@ ignore = [
 ]
 stubPath = 'typings'
 pythonVersion = '3.11'
+
+[tool.ruff]
+select = ["E", "F", "W"]
+line-length = 120
+target-version = 'py38'

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -44,6 +44,11 @@
                       "markdownDescription": "Enables Copilot telemetry requests for `Accept` and `Reject` completions.",
                       "type": "boolean"
                     },
+                    "proxy": {
+                      "default": "",
+                      "markdownDescription": "The HTTP proxy to use for Copilot requests. It's in the form of `username:password@host:port` or just `host:port`.",
+                      "type": "string"
+                    },
                     "completion_style": {
                       "default": "popup",
                       "markdownDescription": "Completion style. `popup` is the default, `phantom` is experimental(there are [well-known issues](https://github.com/TheSecEng/LSP-copilot/issues)).",


### PR DESCRIPTION
Resolves https://github.com/TerminalFi/LSP-copilot/issues/94

Add a `proxy` setting to `settings` in `LSP-copilot.sublime-settings`.

```js
{
	"settings": {
		"proxy": "username:password@host:port" // or just "host:port"
	}
}
```