### PR TITLE
fix: completions panel steals focus

### DIFF
--- a/plugin/ui/panel_completion.py
+++ b/plugin/ui/panel_completion.py
@@ -279,6 +279,8 @@ class _PanelCompletion:
         else:
             self._open_in_group(window, active_group + 1)
 
+        window.focus_view(self.view)
+
     def update(self) -> None:
         window = self.view.window()
         if not window:


### PR DESCRIPTION
Hi there!

I've been trying to use the completions panel with key bindings only, but right now it's not possible because the panel steals focus from the view. This prevents any further view commands and forces you to close the panel using the mouse.

This PR just gives focus back to the view after opening the panel :)