### PR TITLE
Supports the ability to honor `.gitignore` patterns (TOP LEVEL ONLY)

### DIFF
--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -16,7 +16,8 @@
 		"local_checks": false,
 		"telemetry": false,
 		"proxy": "",
-		"completion_style": "popup"
+		"completion_style": "popup",
+		"respect_gitignore": false
 	},
 	// ST4 configuration
 	"selector": "source | text | embedding"

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -57,8 +57,13 @@
                         "popup",
                         "phantom"
                       ]
+                    },
+                    "respect_gitignore": {
+                      "default": false,
+                      "markdownDescription": "Respect `.gitignore` files when sending files to the server.",
+                      "type": "boolean"
                     }
-                  }
+                  },
                 }
               }
             }


### PR DESCRIPTION
Attempt to have LSP-copilot honor `.gitignore` files that are detected at the top level of the window folders. Comparing the View path with the window path to get the correct ignore file.

