### PR TITLE
docs: update URL of Copilot.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ In LSP-copilot's plugin settings, add the following `env` key:
  ```
 
 [Copilot]: https://github.com/features/copilot
-[Copilot.vim]: https://github.com/github/copilot.vim/tree/release/copilot/dist
+[Copilot.vim]: https://github.com/github/copilot.vim
 [LSP]: https://packagecontrol.io/packages/LSP
 [LSP-copilot]: https://packagecontrol.io/packages/LSP-copilot


### PR DESCRIPTION
Copilot.vim changes its directory structure so the link is dead now. I think it's fine to just the the repository URL.