### PR TITLE
chore: bump server to 1.10.0

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -6,13 +6,13 @@
     "packages": {
         "": {
             "dependencies": {
-                "copilot-node-server": "^1.9.4"
+                "copilot-node-server": "^1.10.0"
             }
         },
         "node_modules/copilot-node-server": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.9.4.tgz",
-            "integrity": "sha512-xSEU+CJQWVPFRhxpwaClY+0/uWdiJq2efqoLQiJ3lyQrD73YYOKt7sCQUkincZbQNbM8mIIlC5bQpZPbnjtIkg==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.10.0.tgz",
+            "integrity": "sha512-P2MdhdPraGQjhMkjOGDBzJtOW4WJ8YUxjOxPVFK/PLslWOPk5jD43QWJn94OSmA468/Rdb02KcrfgvdwN/eCLA==",
             "bin": {
                 "copilot-node-server": "bin/copilot-node-server"
             }
@@ -20,9 +20,9 @@
     },
     "dependencies": {
         "copilot-node-server": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.9.4.tgz",
-            "integrity": "sha512-xSEU+CJQWVPFRhxpwaClY+0/uWdiJq2efqoLQiJ3lyQrD73YYOKt7sCQUkincZbQNbM8mIIlC5bQpZPbnjtIkg=="
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.10.0.tgz",
+            "integrity": "sha512-P2MdhdPraGQjhMkjOGDBzJtOW4WJ8YUxjOxPVFK/PLslWOPk5jD43QWJn94OSmA468/Rdb02KcrfgvdwN/eCLA=="
         }
     }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "copilot-node-server": "^1.9.4"
+        "copilot-node-server": "^1.10.0"
     }
 }

--- a/plugin/constants.py
+++ b/plugin/constants.py
@@ -24,7 +24,8 @@ REQ_SIGN_OUT = "signOut"  # done
 # Copilot notifications #
 # --------------------- #
 
+NTFY_FEATURE_FLAGS_NOTIFICATION = "featureFlagsNotification"  # done
 NTFY_LOG_MESSAGE = "LogMessage"  # done
-NTFY_STATUS_NOTIFICATION = "statusNotification"  # done
 NTFY_PANEL_SOLUTION = "PanelSolution"  # done
 NTFY_PANEL_SOLUTION_DONE = "PanelSolutionsDone"  # done
+NTFY_STATUS_NOTIFICATION = "statusNotification"  # done

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -12,6 +12,7 @@ from LSP.plugin.core.typing import Any, Callable, Dict, Optional, Tuple, Union, 
 from lsp_utils import ApiWrapperInterface, NpmClientHandler, notification_handler
 
 from .constants import (
+    NTFY_FEATURE_FLAGS_NOTIFICATION,
     NTFY_LOG_MESSAGE,
     NTFY_PANEL_SOLUTION,
     NTFY_PANEL_SOLUTION_DONE,
@@ -25,6 +26,7 @@ from .constants import (
 from .types import (
     AccountStatus,
     CopilotPayloadCompletions,
+    CopilotPayloadFeatureFlagsNotification,
     CopilotPayloadLogMessage,
     CopilotPayloadPanelSolution,
     CopilotPayloadSignInConfirm,
@@ -224,6 +226,10 @@ class CopilotPlugin(NpmClientHandler):
     def is_valid_for_view(self, view: sublime.View) -> bool:
         session = self.weaksession()
         return bool(session and session.session_view_for_view_async(view))
+
+    @notification_handler(NTFY_FEATURE_FLAGS_NOTIFICATION)
+    def _handle_feature_flags_notification(self, payload: CopilotPayloadFeatureFlagsNotification) -> None:
+        pass
 
     @notification_handler(NTFY_LOG_MESSAGE)
     def _handle_log_message_notification(self, payload: CopilotPayloadLogMessage) -> None:

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -80,6 +80,16 @@ CopilotPayloadCompletions = TypedDict(
     total=True,
 )
 
+CopilotPayloadFeatureFlagsNotification = TypedDict(
+    "CopilotPayloadFeatureFlagsNotification",
+    {
+        "ssc": bool,
+        "chat": bool,
+        "rt": bool,
+    },
+    total=True,
+)
+
 CopilotPayloadGetVersion = TypedDict(
     "CopilotPayloadGetVersion",
     {

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -195,7 +195,7 @@ def prepare_completion_request(view: sublime.View) -> Optional[Dict[str, Any]]:
             "position": {"line": row, "character": col},
             # Buffer Version. Generally this is handled by LSP, but we need to handle it here
             # Will need to test getting the version from LSP
-            "version": 0,
+            "version": view.change_count(),
         }
     }
 


### PR DESCRIPTION
This PR doesn't work by simply updating the server. I got

```
:: [05:53:05.974] <-  LSP-copilot LogMessage: {'message': '[DEBUG] [getCompletions] [2023-08-19T21:53:05.968Z] Producing empty completions due to document version mismatch. Completions requested for document version 0 but document version was 34.', 'level': 0, 'extra': ['Producing empty completions due to document version mismatch. Completions requested for document version 0 but document version was 34.'], 'metadataStr': '[DEBUG] [getCompletions] [2023-08-19T21:53:05.968Z]'}
:: [05:53:05.974] <<< LSP-copilot (49) (duration: 8ms): {'cancellationReason': 'DocumentVersionMismatch', 'completions': []}
```

in LSP's log panel.

---

Also, there is a new notification type.

```
:: [05:55:55.381] <?  LSP-copilot featureFlagsNotification: {'ssc': False, 'chat': True, 'rt': False}
```