### PR TITLE
Added Settings section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On the first time use, follow the steps below:
 
 ## Settings
 
-Provide user settings in LSP-copilot.sublime-settings (Settings... > Package Settings > LSP > Servers > LSP-copilot)
+Settings are provide in the `LSP-copilot.sublime-settings` file, accessible using `Preferences: LSP-copilot Settings` in the command palette.
 
 | Setting                       | Type    | Default | Description                                                         |
 | ----------------------------- | ------- | ------- | ------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ On the first time use, follow the steps below:
     1. Return to Sublime Text and press `OK` on the dialog.
     1. If you see a "sign in OK" dialog, LSP-copilot should start working since then.
 
+## Settings
+
+Provide user settings in LSP-copilot.sublime-settings (Settings... > Package Settings > LSP > Servers > LSP-copilot)
+
+| Setting                       | Type    | Default | Description                                                         |
+| ----------------------------- | ------- | ------- | ------------------------------------------------------------------- |
+| auto_ask_completions          | boolean | true    | Auto ask the server for completions. Otherwise, you have to trigger it manually. |
+| debug                         | boolean | false   | Enables `debug` mode for LSP-copilot. Enabling all commands regardless of status requirements. |
+| hook_to_auto_complete_command | boolean | false   | Ask the server for completions when the `auto_complete` command is called. |
+| local_checks                  | boolean | false   | Enables local checks. This feature is not fully understood yet.      |
+| telemetry                     | boolean | false   | Enables Copilot telemetry requests for `Accept` and `Reject` completions. |
+| proxy                         | string  |        | The HTTP proxy to use for Copilot requests. It's in the form of `username:password@host:port` or just `host:port`. |
+| completion_style              | string  | popup   | Completion style. `popup` is the default, `phantom` is experimental ([there are well-known issues](https://github.com/TheSecEng/LSP-copilot/issues)). |
 
 ## FAQs
 


### PR DESCRIPTION
Thanks for LSP-copilot! To understand the settings I searched and came across [this issue](https://github.com/TerminalFi/LSP-copilot/issues/110) which was helpful. I think including this on the repo README.md makes sense.

Added section/table to README.md describing the Type/Default/Description for the available Settings as described in the sublime-package.json. Hopefully others will find this helpful.