### PR TITLE
chore: bump server to 1.24.0

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -5,13 +5,13 @@
     "packages": {
         "": {
             "dependencies": {
-                "copilot-node-server": "^1.14.0"
+                "copilot-node-server": "^1.24.0"
             }
         },
         "node_modules/copilot-node-server": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.14.0.tgz",
-            "integrity": "sha512-akyEGXwu/jZwc7+QIxkr/kKxiCp6yCQ9742J16/YposLMcgQHUDlag9WP+TjxD6HXPRFU53+8mKrUld5CS+slw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.24.0.tgz",
+            "integrity": "sha512-RH4tqfRt5Go656rz8i3Oeh4ywFQKjc4I2ETu/KAZW3h+ElU/s9FvMBreBzBu/0KEPBC5PPu6dsGMJvVYYx7WfQ==",
             "bin": {
                 "copilot-node-server": "bin/copilot-node-server"
             }
@@ -19,9 +19,9 @@
     },
     "dependencies": {
         "copilot-node-server": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.14.0.tgz",
-            "integrity": "sha512-akyEGXwu/jZwc7+QIxkr/kKxiCp6yCQ9742J16/YposLMcgQHUDlag9WP+TjxD6HXPRFU53+8mKrUld5CS+slw=="
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/copilot-node-server/-/copilot-node-server-1.24.0.tgz",
+            "integrity": "sha512-RH4tqfRt5Go656rz8i3Oeh4ywFQKjc4I2ETu/KAZW3h+ElU/s9FvMBreBzBu/0KEPBC5PPu6dsGMJvVYYx7WfQ=="
         }
     }
 }

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "copilot-node-server": "^1.14.0"
+        "copilot-node-server": "^1.24.0"
     }
 }

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -87,8 +87,9 @@ class CopilotPlugin(NpmClientHandler):
         server_directory,
         "node_modules",
         "copilot-node-server",
-        "bin",
-        "copilot-node-server",
+        "copilot",
+        "dist",
+        "agent.js",
     )
 
     plugin_mapping = weakref.WeakValueDictionary()  # type: weakref.WeakValueDictionary[int, CopilotPlugin]


### PR DESCRIPTION
Hmm... somehow `node bin/copilot-node-server --stdio` doesn't work while `node copilot/dist/agent.js --stdio` works. Temporarily switch to `copilot/dist/agent.js`.

