### PR TITLE
feat: add keybindings edit in main menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,11 +17,25 @@
                 "children": [
                   {
                     "caption": "LSP-copilot",
-                    "command": "edit_settings",
-                    "args": {
-                      "base_file": "${packages}/LSP-copilot/LSP-copilot.sublime-settings",
-                      "default": "// Settings in here override those in \"LSP-copilot/LSP-copilot.sublime-settings\"\n\n{\n\t$0\n}\n",
-                    },
+                    "children": [
+                      {
+                        "caption": "Settings",
+                        "command": "edit_settings",
+                        "args": {
+                          "base_file": "${packages}/LSP-copilot/LSP-copilot.sublime-settings",
+                          "default": "// Settings in here override those in \"LSP-copilot/LSP-copilot.sublime-settings\"\n\n{\n\t$0\n}\n",
+                        },
+                      },
+                      {
+                        "caption": "Key Bindings",
+                        "command": "edit_settings",
+                        "args": {
+                          "base_file": "${packages}/LSP-copilot/Default.sublime-keymap",
+                          "user_file": "${packages}/User/Default (${platform}).sublime-keymap",
+                          "default": "[\n\t$0\n]\n",
+                        }
+                      },
+                    ],
                   },
                 ],
               },


### PR DESCRIPTION
Resolves https://github.com/TerminalFi/LSP-copilot/issues/134#issuecomment-1984397250

---

Change LSP-copilot's main menu into

![image](https://github.com/TerminalFi/LSP-copilot/assets/6594915/3254cb49-a2c5-4d0b-aa33-8cdf7f18d598)

And pressing the `Key Bindings` opens

![image](https://github.com/TerminalFi/LSP-copilot/assets/6594915/cb5df2c5-e2a1-45a9-8ded-7a624c392530)
