### PR TITLE
chore: change copilot_accept_completion keybinding to ctrl+tab

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,7 +1,7 @@
 [
     {
         "keys": [
-            "tab"
+            "ctrl+tab"
         ],
         "command": "copilot_accept_completion",
         "context": [


### PR DESCRIPTION
# This change will break almost ALL LSP-copilot user's setup.

`ctrl+tab` is just an example because I don't know what would be suitable for this.

Previously it uses Tab, which is the same with ST's autocompletion, as the keybinding. It's not obvious that what should happen after pressing Tab if there are both copilot/ST completions on the screen. One user may want to use copilot's while another may want ST's.

Or, we assign no keybinding and let users to do their own. (Need to be documented in README.)

---

Resolves #138
Resolves #73