### PR TITLE
feat: add setting: commit_completion_on_tab

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -6,6 +6,9 @@
         "command": "copilot_accept_completion",
         "context": [
             {
+                "key": "copilot.commit_completion_on_tab"
+            },
+            {
                 "key": "copilot.is_on_completion"
             }
         ]

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -11,6 +11,7 @@
 	],
 	"settings": {
 		"auto_ask_completions": true,
+		"commit_completion_on_tab": true,
 		"debug": false,
 		"hook_to_auto_complete_command": false,
 		"local_checks": false,

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Settings are provide in the `LSP-copilot.sublime-settings` file, accessible usin
 | Setting                       | Type    | Default | Description                                                         |
 | ----------------------------- | ------- | ------- | ------------------------------------------------------------------- |
 | auto_ask_completions          | boolean | true    | Auto ask the server for completions. Otherwise, you have to trigger it manually. |
+| commit_completion_on_tab      | boolean | true    | Use the `Tab` key for committing Copilot's completion. This may conflict with Sublime Text's `auto_complete_commit_on_tab` setting. |
 | debug                         | boolean | false   | Enables `debug` mode for LSP-copilot. Enabling all commands regardless of status requirements. |
 | hook_to_auto_complete_command | boolean | false   | Ask the server for completions when the `auto_complete` command is called. |
 | local_checks                  | boolean | false   | Enables local checks. This feature is not fully understood yet.      |
@@ -45,10 +46,14 @@ Settings are provide in the `LSP-copilot.sublime-settings` file, accessible usin
 
 ## FAQs
 
-### Pressing `Tab` commits autocompletion rather than Copilot's suggestion
+### I don't want to use `Tab` for committing Copilot's completion
 
-There is no way for a plugin to know which one is wanted. But you can define your own dedicate keybinding to commit
-Copilot's suggestion.
+It's likely that Copilot's completion appears along with Sublime Text's autocompletion
+and both of them use `Tab` for committing the completion. This may cause a nondeterministic result.
+
+Thus, you may want to let only one of them (or none) use the `Tab` key.
+If you don't want LSP-copilot to use the `Tab` key for committing the completion.
+You can set LSP-copilot's `commit_completion_on_tab` setting to `false` and add a custom keybinding like below.
 
 ```js
 {
@@ -56,7 +61,7 @@ Copilot's suggestion.
     "command": "copilot_accept_completion",
     "context": [
         {
-            "key": "setting.copilot.completion.is_visible"
+            "key": "copilot.is_on_completion"
         }
     ]
 },

--- a/plugin/listeners.py
+++ b/plugin/listeners.py
@@ -98,6 +98,14 @@ class ViewEventListener(sublime_plugin.ViewEventListener):
 
             return test(beginning_of_line.strip() != "" or not re.match(r"\s", vcm.current_completion["displayText"]))
 
+        plugin, session = CopilotPlugin.plugin_session(self.view)
+
+        if not plugin or not session:
+            return None
+
+        if key == "copilot.commit_completion_on_tab":
+            return test(get_session_setting(session, "commit_completion_on_tab"))
+
         return None
 
     def on_post_text_command(self, command_name: str, args: Optional[Dict[str, Any]]) -> None:

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -24,6 +24,11 @@
                       "description": "Auto ask the server for completions. Otherwise, you have to trigger it manually.",
                       "type": "boolean"
                     },
+                    "commit_completion_on_tab": {
+                      "default": true,
+                      "markdownDescription": "Use the `Tab` key for committing Copilot's completion. This may conflict with Sublime Text's `auto_complete_commit_on_tab` setting.",
+                      "type": "boolean"
+                    },
                     "debug": {
                       "default": false,
                       "markdownDescription": "Enables `debug` mode fo the LSP-copilot. Enabling all commands regardless of status requirements.",


### PR DESCRIPTION
If it's `false`, the user has to add a keybinding for committing completion by himself/herself.

Resolves https://github.com/TerminalFi/LSP-copilot/issues/138
Resolves https://github.com/TerminalFi/LSP-copilot/issues/73