### PR TITLE
Misc fixes and adding commands to allow users to discover more features

### DIFF
--- a/Main.sublime-commands
+++ b/Main.sublime-commands
@@ -4,6 +4,55 @@
         "command": "copilot_conversation_chat"
     },
     {
+        "caption": "Copilot: Explain",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/explain {{ sel[0] }}"
+        }
+    },
+    {
+        "caption": "Copilot: Generate Tests",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/tests {{ sel[0] }}"
+        }
+    },
+    {
+        "caption": "Copilot: Generate Docs",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/doc {{ sel[0] }}"
+        }
+    },
+    {
+        "caption": "Copilot: Fix This",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/fix {{ sel[0] }}"
+        }
+    },
+    {
+        "caption": "Copilot: Simplify This",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/simplify {{ sel[0] }}"
+        }
+    },
+    {
+        "caption": "Copilot: Feedback",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/feedback"
+        }
+    },
+    {
+        "caption": "Copilot: Help",
+        "command": "copilot_conversation_chat",
+        "args": {
+            "message": "/help"
+        }
+    },
+    {
         "caption": "Copilot: Destroy Conversation",
         "command": "copilot_conversation_destroy"
     },

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -505,7 +505,7 @@ class CopilotConversationAgentsCommand(LspTextCommand):
         window = self.view.window()
         if not window:
             return
-        window.show_quick_panel([(item["id"], item["description"]) for item in payload], lambda _: None)
+        window.show_quick_panel([[item["slug"], item["description"]] for item in payload], lambda _: None)
 
 
 class CopilotConversationTemplatesCommand(LspTextCommand):

--- a/plugin/templates/chat_panel.md.jinja
+++ b/plugin/templates/chat_panel.md.jinja
@@ -39,5 +39,5 @@
 {% endfor %}
 
 {% if follow_up %}
-Follow up: <a class="icon-link" href='{{ follow_up_url }}'>{{ follow_up }}</a>
+Follow up: <a class="icon-link follow-up" href='{{ follow_up_url }}'>{{ follow_up }}</a>
 {% endif %}

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -170,7 +170,8 @@ class CopilotPayloadConversationTemplate(TypedDict, total=True):
 
 
 class CopilotRequestCoversationAgent(TypedDict, total=True):
-    id: str
+    slug: str
+    name: str
     description: str
 
 

--- a/plugin/ui/chat.py
+++ b/plugin/ui/chat.py
@@ -179,7 +179,7 @@ class _ConversationEntry:
             follow_up=self.conversation_manager.follow_up,
             follow_up_url=sublime.command_url(
                 "copilot_conversation_chat_shim",
-                {"window_id": self.conversation_manager.window.id(), "follow_up": self.conversation_manager.follow_up},
+                {"window_id": self.conversation_manager.window.id(), "message": self.conversation_manager.follow_up},
             ),
             close_url=sublime.command_url(
                 "copilot_conversation_close",

--- a/plugin/ui/chat.py
+++ b/plugin/ui/chat.py
@@ -34,7 +34,7 @@ class WindowConversationManager:
         )
 
     @last_active_view_id.setter
-    def last_active_view_id(self, value: str) -> None:
+    def last_active_view_id(self, value: int) -> None:
         set_copilot_setting(self.window, COPILOT_WINDOW_CONVERSATION_SETTINGS_PREFIX, "view_last_active_view_id", value)
 
     @property


### PR DESCRIPTION
Copilot Chat natively supports Templates for questions

```
/fix
/doc
/tests
/explain
/simplify
/feedback
/help
```

This just makes them easier to use by adding Command entries and also auto injecting the current selection if not specified