### PR TITLE
feat: allow user customizable prompts for reusable logic

### DIFF
--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -23,7 +23,8 @@
 		"status_text": "{% if is_copilot_ignored %}{{ is_copilot_ignored }}{% elif is_waiting %}{{ is_waiting }}{% elif server_version %}v{{ server_version }}{% endif %}",
 		"prompts": {
 			"/review": {
-				"title": "Review",
+				"id": "review",
+				"description": "Review code and provide feedback.",
 				"prompt": [
 					"Review the provided code and provide feedback.",
 					"Feedback should first reply back with the line or lines of code, followed by the feedback about the code.",

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -21,6 +21,24 @@
 		// The (Jinja2) template of the status bar text which is inside the parentheses `(...)`.
 		// See https://jinja.palletsprojects.com/templates/
 		"status_text": "{% if is_copilot_ignored %}{{ is_copilot_ignored }}{% elif is_waiting %}{{ is_waiting }}{% elif server_version %}v{{ server_version }}{% endif %}",
+		"prompts": {
+			"/review": {
+				"title": "Review",
+				"prompt": [
+					"Review the provided code and provide feedback.",
+					"Feedback should first reply back with the line or lines of code, followed by the feedback about the code.",
+					"Do not invent new problems.",
+					"The feedback should be constructive and aim to improve the code quality.",
+					"If there are no issues detected, reply that the code looks good and no changes are necessary.",
+					"Group related feedback into a single comment if possible.",
+					"Present each comment with a brief description of the issue and a suggestion for improvement.",
+					"Use the format `Comment #: [description] [suggestion]` for each comment, # representing the number of comments.",
+					"At last provide a summary of the overall code quality and any general suggestions for improvement.",
+					"",
+					"{{sel[0]}}",
+				]
+			}
+		}
 	},
 	// ST4 configuration
 	"selector": "source | text | embedding"

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -21,8 +21,8 @@
 		// The (Jinja2) template of the status bar text which is inside the parentheses `(...)`.
 		// See https://jinja.palletsprojects.com/templates/
 		"status_text": "{% if is_copilot_ignored %}{{ is_copilot_ignored }}{% elif is_waiting %}{{ is_waiting }}{% elif server_version %}v{{ server_version }}{% endif %}",
-		"prompts": {
-			"/review": {
+		"prompts": [
+			{
 				"id": "review",
 				"description": "Review code and provide feedback.",
 				"prompt": [
@@ -39,7 +39,7 @@
 					"{{sel[0]}}",
 				]
 			}
-		}
+		]
 	},
 	// ST4 configuration
 	"selector": "source | text | embedding"

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -26,7 +26,7 @@
 				"id": "review",
 				"description": "Review code and provide feedback.",
 				"prompt": [
-					"Review the provided code and provide feedback.",
+					"Review the referenced code and provide feedback.",
 					"Feedback should first reply back with the line or lines of code, followed by the feedback about the code.",
 					"Do not invent new problems.",
 					"The feedback should be constructive and aim to improve the code quality.",

--- a/LSP-copilot.sublime-settings
+++ b/LSP-copilot.sublime-settings
@@ -35,8 +35,6 @@
 					"Present each comment with a brief description of the issue and a suggestion for improvement.",
 					"Use the format `Comment #: [description] [suggestion]` for each comment, # representing the number of comments.",
 					"At last provide a summary of the overall code quality and any general suggestions for improvement.",
-					"",
-					"{{sel[0]}}",
 				]
 			}
 		]

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -33,7 +33,7 @@ from .helpers import (
     ActivityIndicator,
     CopilotIgnore,
     GithubInfo,
-    prepare_completion_request,
+    prepare_completion_request_doc,
     preprocess_completions,
     preprocess_panel_completions,
 )
@@ -399,7 +399,7 @@ class CopilotPlugin(NpmClientHandler):
         ):
             return
 
-        if not (params := prepare_completion_request(view)):
+        if not (doc := prepare_completion_request_doc(view)):
             return
 
         if no_callback:
@@ -410,7 +410,7 @@ class CopilotPlugin(NpmClientHandler):
                 self._activity_indicator.start()
             callback = functools.partial(self._on_get_completions, view, region=sel[0].to_tuple())
 
-        session.send_request_async(Request(request, params), callback)
+        session.send_request_async(Request(request, {"doc": doc}), callback)
 
     def _on_get_completions(
         self,

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -45,6 +45,7 @@ from .helpers import (
     preprocess_message_for_html,
 )
 from .types import (
+    CopilotPayloadConversationPreconditions,
     CopilotPayloadConversationTemplate,
     CopilotPayloadFileStatus,
     CopilotPayloadGetVersion,
@@ -235,7 +236,11 @@ class CopilotConversationChatCommand(LspTextCommand):
         )
 
     def _on_result_conversation_preconditions(
-        self, plugin: CopilotPlugin, session: Session, payload, initial_message: str
+        self,
+        plugin: CopilotPlugin,
+        session: Session,
+        payload: CopilotPayloadConversationPreconditions,
+        initial_message: str,
     ) -> None:
         if not (window := self.view.window()):
             return

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -41,6 +41,7 @@ from .decorators import _must_be_active_view
 from .helpers import (
     GithubInfo,
     prepare_completion_request,
+    prepare_conversation_turn_request,
     preprocess_chat_message,
     preprocess_message_for_html,
 )
@@ -316,21 +317,10 @@ class CopilotConversationChatCommand(LspTextCommand):
             "hideText": False,
         })
 
-        if not (request := prepare_completion_request(view)):
-            return
-
         session.send_request(
             Request(
                 REQ_CONVERSATION_TURN,
-                {
-                    "conversationId": wcm.conversation_id,
-                    "message": msg,
-                    "workDoneToken": f"copilot_chat://{wcm.window.id()}",
-                    "doc": request["doc"],
-                    "computeSuggestions": True,
-                    "references": [],
-                    "source": "panel",
-                },
+                prepare_conversation_turn_request(wcm.conversation_id, wcm.window.id(), msg, view),
             ),
             lambda _: wcm.prompt(callback=lambda x: self._on_prompt(plugin, session, x)),
         )

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -40,7 +40,7 @@ from .constants import (
 from .decorators import _must_be_active_view
 from .helpers import (
     GithubInfo,
-    prepare_completion_request,
+    prepare_completion_request_doc,
     prepare_conversation_turn_request,
     preprocess_chat_message,
     preprocess_message_for_html,
@@ -617,7 +617,7 @@ class CopilotRejectCompletionCommand(CopilotTextCommand):
 class CopilotGetPanelCompletionsCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
-        if not (params := prepare_completion_request(self.view)):
+        if not (doc := prepare_completion_request_doc(self.view)):
             return
 
         vcm = ViewPanelCompletionManager(self.view)
@@ -625,7 +625,7 @@ class CopilotGetPanelCompletionsCommand(CopilotTextCommand):
         vcm.is_visible = True
         vcm.completions = []
 
-        params["panelId"] = vcm.panel_id
+        params = {"doc": doc, "panelId": vcm.panel_id}
         session.send_request(Request(REQ_GET_PANEL_COMPLETIONS, params), self._on_result_get_panel_completions)
 
     def _on_result_get_panel_completions(self, payload: CopilotPayloadPanelCompletionSolutionCount) -> None:

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -200,12 +200,14 @@ class CopilotClosePanelCompletionCommand(CopilotWindowCommand):
             view = self.window.active_view()
         else:
             view = find_view_by_id(view_id)
+
         if not view:
             return
+
         ViewPanelCompletionManager(view).close()
 
 
-class CopilotConversationChatShimCommand(LspWindowCommand):
+class CopilotConversationChatShimCommand(CopilotWindowCommand):
     def run(self, window_id: int, message: str = "") -> None:
         if not (window := find_window_by_id(window_id)):
             return
@@ -217,7 +219,7 @@ class CopilotConversationChatShimCommand(LspWindowCommand):
         view.run_command("copilot_conversation_chat", {"message": message})
 
 
-class CopilotConversationChatCommand(LspTextCommand):
+class CopilotConversationChatCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit, message: str = "") -> None:
         if not (window := self.view.window()):
@@ -337,7 +339,7 @@ class CopilotConversationCloseCommand(CopilotWindowCommand):
         WindowConversationManager(window).close()
 
 
-class CopilotConversationRatingShimCommand(LspWindowCommand):
+class CopilotConversationRatingShimCommand(CopilotWindowCommand):
     def run(self, turn_id: str, rating: int) -> None:
         wcm = WindowConversationManager(self.window)
         if not (view := find_view_by_id(wcm.last_active_view_id)):
@@ -345,7 +347,7 @@ class CopilotConversationRatingShimCommand(LspWindowCommand):
         view.run_command("copilot_conversation_rating", {"turn_id": turn_id, "rating": rating})
 
 
-class CopilotConversationRatingCommand(LspTextCommand):
+class CopilotConversationRatingCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit, turn_id: str, rating: int) -> None:
         session.send_request(
@@ -364,7 +366,7 @@ class CopilotConversationRatingCommand(LspTextCommand):
         pass
 
 
-class CopilotConversationDestroyShimCommand(LspWindowCommand):
+class CopilotConversationDestroyShimCommand(CopilotWindowCommand):
     def run(self, conversation_id: str) -> None:
         wcm = WindowConversationManager(self.window)
         if not (view := find_view_by_id(wcm.last_active_view_id)):
@@ -372,7 +374,7 @@ class CopilotConversationDestroyShimCommand(LspWindowCommand):
         view.run_command("copilot_conversation_destroy", {"conversation_id": conversation_id})
 
 
-class CopilotConversationDestroyCommand(LspTextCommand):
+class CopilotConversationDestroyCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit, conversation_id: str) -> None:
         if not (
@@ -411,7 +413,7 @@ class CopilotConversationDestroyCommand(LspTextCommand):
         return super().is_enabled() and bool(WindowConversationManager(window).conversation_id)
 
 
-class CopilotConversationTurnDeleteShimCommand(LspWindowCommand):
+class CopilotConversationTurnDeleteShimCommand(CopilotWindowCommand):
     def run(self, window_id: int, conversation_id: str, turn_id: str) -> None:
         wcm = WindowConversationManager(self.window)
         if not (view := find_view_by_id(wcm.last_active_view_id)):
@@ -422,7 +424,7 @@ class CopilotConversationTurnDeleteShimCommand(LspWindowCommand):
         )
 
 
-class CopilotConversationTurnDeleteCommand(LspTextCommand):
+class CopilotConversationTurnDeleteCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(
         self,
@@ -484,7 +486,7 @@ class CopilotConversationTurnDeleteCommand(LspTextCommand):
         wcm.update()
 
 
-class CopilotConversationCopyCodeCommand(LspWindowCommand):
+class CopilotConversationCopyCodeCommand(CopilotWindowCommand):
     def run(self, window_id: int, code_block_index: int) -> None:
         if not (window := find_window_by_id(window_id)):
             return
@@ -496,7 +498,7 @@ class CopilotConversationCopyCodeCommand(LspWindowCommand):
         sublime.set_clipboard(code)
 
 
-class CopilotConversationInsertCodeShimCommand(LspWindowCommand):
+class CopilotConversationInsertCodeShimCommand(CopilotWindowCommand):
     def run(self, window_id: int, code_block_index: int) -> None:
         if not (window := find_window_by_id(window_id)):
             return
@@ -511,7 +513,7 @@ class CopilotConversationInsertCodeShimCommand(LspWindowCommand):
         view.run_command("copilot_conversation_insert_code", {"characters": code})
 
 
-class CopilotConversationInsertCodeCommand(LspTextCommand):
+class CopilotConversationInsertCodeCommand(CopilotTextCommand):
     def run(self, edit: sublime.Edit, characters: str) -> None:
         if len(self.view.sel()) > 1:
             return
@@ -521,7 +523,7 @@ class CopilotConversationInsertCodeCommand(LspTextCommand):
         self.view.insert(edit, begin, characters)
 
 
-class CopilotConversationAgentsCommand(LspTextCommand):
+class CopilotConversationAgentsCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
         session.send_request(Request(REQ_CONVERSATION_AGENTS, {"options": {}}), self._on_result_conversation_agents)
@@ -533,7 +535,7 @@ class CopilotConversationAgentsCommand(LspTextCommand):
         window.show_quick_panel([[item["slug"], item["description"]] for item in payload], lambda _: None)
 
 
-class CopilotConversationTemplatesCommand(LspTextCommand):
+class CopilotConversationTemplatesCommand(CopilotTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
         user_prompts: list[CopilotUserDefinedPromptTemplates] = session.config.settings.get("prompts") or []

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -538,7 +538,7 @@ class CopilotConversationTemplatesCommand(LspTextCommand):
 
     def _on_result_conversation_templates(
         self,
-        user_defined_templates: dict[CopilotUserDefinedPromptTemplates],
+        user_defined_templates: dict[str, CopilotUserDefinedPromptTemplates],
         payload: list[CopilotPayloadConversationTemplate],
     ) -> None:
         if not (window := self.view.window()):

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -57,7 +57,7 @@ from .types import (
     CopilotPayloadSignInConfirm,
     CopilotPayloadSignInInitiate,
     CopilotPayloadSignOut,
-    CopilotRequestCoversationAgent,
+    CopilotRequestConversationAgent,
     CopilotUserDefinedPromptTemplates,
     T_Callable,
 )
@@ -356,10 +356,10 @@ class CopilotConversationRatingCommand(LspTextCommand):
                     "rating": rating,
                 },
             ),
-            self._on_result_coversation_rating,
+            self._on_result_conversation_rating,
         )
 
-    def _on_result_coversation_rating(self, payload: Literal["OK"]) -> None:
+    def _on_result_conversation_rating(self, payload: Literal["OK"]) -> None:
         # Returns OK
         pass
 
@@ -390,10 +390,10 @@ class CopilotConversationDestroyCommand(LspTextCommand):
                     "options": {},
                 },
             ),
-            self._on_result_coversation_destroy,
+            self._on_result_conversation_destroy,
         )
 
-    def _on_result_coversation_destroy(self, payload: str) -> None:
+    def _on_result_conversation_destroy(self, payload: str) -> None:
         if not (window := self.view.window()):
             return
         if payload != "OK":
@@ -455,10 +455,10 @@ class CopilotConversationTurnDeleteCommand(LspTextCommand):
                     "options": {},
                 },
             ),
-            lambda x: self._on_result_coversation_turn_delete(window_id, conversation_id, turn_id, x),
+            lambda x: self._on_result_conversation_turn_delete(window_id, conversation_id, turn_id, x),
         )
 
-    def _on_result_coversation_turn_delete(
+    def _on_result_conversation_turn_delete(
         self,
         window_id: int,
         conversation_id: str,
@@ -524,9 +524,9 @@ class CopilotConversationInsertCodeCommand(LspTextCommand):
 class CopilotConversationAgentsCommand(LspTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
-        session.send_request(Request(REQ_CONVERSATION_AGENTS, {"options": {}}), self._on_result_coversation_agents)
+        session.send_request(Request(REQ_CONVERSATION_AGENTS, {"options": {}}), self._on_result_conversation_agents)
 
-    def _on_result_coversation_agents(self, payload: list[CopilotRequestCoversationAgent]) -> None:
+    def _on_result_conversation_agents(self, payload: list[CopilotRequestConversationAgent]) -> None:
         window = self.view.window()
         if not window:
             return

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -407,10 +407,13 @@ class CopilotConversationDestroyCommand(CopilotTextCommand):
         wcm.close()
         wcm.reset()
 
-    def is_enabled(self, event: dict[Any, Any] | None = None, point: int | None = None) -> bool:
+    def is_enabled(self, event: dict[Any, Any] | None = None, point: int | None = None) -> bool:  # type: ignore
         if not (window := self.view.window()):
             return False
-        return super().is_enabled() and bool(WindowConversationManager(window).conversation_id)
+        return bool(
+            super().is_enabled()  # type: ignore
+            and WindowConversationManager(window).conversation_id
+        )
 
 
 class CopilotConversationTurnDeleteShimCommand(CopilotWindowCommand):

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -244,7 +244,7 @@ class CopilotConversationChatCommand(LspTextCommand):
         if not (view := find_view_by_id(wcm.last_active_view_id)):
             return
 
-        user_prompts = session.config.settings.get("prompts") or {}
+        user_prompts = session.config.settings.get("prompts") or []
         is_template, msg = preprocess_chat_message(view, initial_message, user_prompts)
         if msg:
             wcm.append_conversation_entry({
@@ -294,7 +294,7 @@ class CopilotConversationChatCommand(LspTextCommand):
 
         if not (view := find_view_by_id(wcm.last_active_view_id)):
             return
-        user_prompts = session.config.settings.get("prompts") or {}
+        user_prompts = session.config.settings.get("prompts") or []
         is_template, msg = preprocess_chat_message(view, msg, user_prompts)
         wcm.append_conversation_entry({
             "kind": plugin.get_account_status().user or "user",
@@ -530,7 +530,7 @@ class CopilotConversationAgentsCommand(LspTextCommand):
 class CopilotConversationTemplatesCommand(LspTextCommand):
     @_provide_plugin_session()
     def run(self, plugin: CopilotPlugin, session: Session, _: sublime.Edit) -> None:
-        user_defined_templates = session.config.settings.get("prompts") or {}
+        user_defined_templates = session.config.settings.get("prompts") or []
         session.send_request(
             Request(REQ_CONVERSATION_TEMPLATES, {"options": {}}),
             lambda payload: self._on_result_conversation_templates(user_defined_templates, payload),

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -318,6 +318,7 @@ class CopilotConversationChatCommand(LspTextCommand):
         })
         if not (request := prepare_conversation_turn_request(wcm.conversation_id, wcm.window.id(), msg, view)):
             return
+
         session.send_request(
             Request(REQ_CONVERSATION_TURN, request),
             lambda _: wcm.prompt(callback=lambda x: self._on_prompt(plugin, session, x)),

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -538,22 +538,25 @@ class CopilotConversationTemplatesCommand(LspTextCommand):
 
     def _on_result_conversation_templates(
         self,
-        user_defined_templates: dict[str, CopilotUserDefinedPromptTemplates],
+        user_defined_templates: list[CopilotUserDefinedPromptTemplates],
         payload: list[CopilotPayloadConversationTemplate],
     ) -> None:
         if not (window := self.view.window()):
             return
 
-        prompts = [[item["id"], item["description"], ", ".join(item["scopes"])] for item in payload] + [
-            [user_defined_templates[template]["id"], user_defined_templates[template]["description"], "chat-panel"]
-            for template in user_defined_templates.keys()
+        templates = payload + user_defined_templates
+        prompts = [
+            [item["id"], item["description"], ", ".join(item["scopes"]) if item.get("scopes", None) else "chat-panel"]
+            for item in templates
         ]
         window.show_quick_panel(
             prompts,
-            lambda index: self._on_selected(index, prompts),
+            lambda index: self._on_selected(index, templates),
         )
 
-    def _on_selected(self, index: int, items: list[CopilotPayloadConversationTemplate]) -> None:
+    def _on_selected(
+        self, index: int, items: list[CopilotPayloadConversationTemplate | CopilotUserDefinedPromptTemplates]
+    ) -> None:
         if index == -1:
             return
         self.view.run_command("copilot_conversation_chat", {"message": f'/{items[index]["id"]}'})

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -243,7 +243,8 @@ class CopilotConversationChatCommand(LspTextCommand):
         if not (view := find_view_by_id(wcm.last_active_view_id)):
             return
 
-        is_template, msg = preprocess_chat_message(view, initial_message)
+        user_prompts = session.config.settings.get("prompts") or {}
+        is_template, msg = preprocess_chat_message(view, initial_message, user_prompts)
         if msg:
             wcm.append_conversation_entry({
                 "kind": plugin.get_account_status().user or "user",
@@ -292,8 +293,8 @@ class CopilotConversationChatCommand(LspTextCommand):
 
         if not (view := find_view_by_id(wcm.last_active_view_id)):
             return
-
-        is_template, msg = preprocess_chat_message(view, msg)
+        user_prompts = session.config.settings.get("prompts") or {}
+        is_template, msg = preprocess_chat_message(view, msg, user_prompts)
         wcm.append_conversation_entry({
             "kind": plugin.get_account_status().user or "user",
             "conversationId": wcm.conversation_id,

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -45,6 +45,7 @@ from .helpers import (
     preprocess_message_for_html,
 )
 from .types import (
+    CopilotPayloadConversationCreate,
     CopilotPayloadConversationPreconditions,
     CopilotPayloadConversationTemplate,
     CopilotPayloadFileStatus,
@@ -279,7 +280,12 @@ class CopilotConversationChatCommand(LspTextCommand):
         wcm.is_waiting = True
         wcm.update()
 
-    def _on_result_conversation_create(self, plugin: CopilotPlugin, session: Session, payload) -> None:
+    def _on_result_conversation_create(
+        self,
+        plugin: CopilotPlugin,
+        session: Session,
+        payload: CopilotPayloadConversationCreate,
+    ) -> None:
         if not (window := self.view.window()):
             return
 
@@ -398,7 +404,7 @@ class CopilotConversationDestroyCommand(LspTextCommand):
             self._on_result_coversation_destroy,
         )
 
-    def _on_result_coversation_destroy(self, payload) -> None:
+    def _on_result_coversation_destroy(self, payload: str) -> None:
         if not (window := self.view.window()):
             return
         if payload != "OK":
@@ -463,7 +469,13 @@ class CopilotConversationTurnDeleteCommand(LspTextCommand):
             lambda x: self._on_result_coversation_turn_delete(window_id, conversation_id, turn_id, x),
         )
 
-    def _on_result_coversation_turn_delete(self, window_id: int, conversation_id: str, turn_id: str, payload) -> None:
+    def _on_result_coversation_turn_delete(
+        self,
+        window_id: int,
+        conversation_id: str,
+        turn_id: str,
+        payload: str,
+    ) -> None:
         if payload != "OK":
             status_message("Failed to delete turn.")
             return

--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -316,12 +316,10 @@ class CopilotConversationChatCommand(LspTextCommand):
             "annotations": [],
             "hideText": False,
         })
-
+        if not (request := prepare_conversation_turn_request(wcm.conversation_id, wcm.window.id(), msg, view)):
+            return
         session.send_request(
-            Request(
-                REQ_CONVERSATION_TURN,
-                prepare_conversation_turn_request(wcm.conversation_id, wcm.window.id(), msg, view),
-            ),
+            Request(REQ_CONVERSATION_TURN, request),
             lambda _: wcm.prompt(callback=lambda x: self._on_prompt(plugin, session, x)),
         )
         wcm.is_waiting = True

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -214,12 +214,13 @@ def prepare_conversation_turn_request(
     for selection in view.sel():
         if selection.empty() or view.substr(selection).strip() == "":
             continue
+        file_path = view.file_name() or f"buffer:{view.buffer().id()}"
         selection_start = view.rowcol(selection.begin())
         selection_end = view.rowcol(selection.end())
         turn["references"].append({
             "type": "file",
             "status": "included",
-            "uri": filename_to_uri(view.file_name()),
+            "uri": file_path if file_path.startswith("buffer:") else file_path and filename_to_uri(file_path),
             "range": initial_doc["doc"]["position"],
             "visibleRange": {
                 "start": {"line": visible_start[0], "character": visible_start[1]},

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -20,7 +20,7 @@ from .settings import get_plugin_setting_dotted
 from .types import (
     CopilotPayloadCompletion,
     CopilotPayloadPanelSolution,
-    CopilotRequestCoversationTurn,
+    CopilotRequestConversationTurn,
     CopilotUserDefinedPromptTemplates,
 )
 from .utils import (
@@ -197,10 +197,10 @@ def prepare_conversation_turn_request(
     message: str,
     view: sublime.View,
     source: Literal["panel", "inline"] = "panel",
-) -> CopilotRequestCoversationTurn | None:
+) -> CopilotRequestConversationTurn | None:
     if not (initial_doc := prepare_completion_request(view, max_selections=5)):
         return None
-    turn: CopilotRequestCoversationTurn = {
+    turn: CopilotRequestConversationTurn = {
         "conversationId": conversation_id,
         "message": message,
         "workDoneToken": f"copilot_chat://{window_id}",

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -227,16 +227,17 @@ def preprocess_chat_message(
 
     if enum_has_value(CopilotConversationTemplates, message):
         is_template = True
-        message += " {{ sel[0] }}"
+        message += " {{ code }}"
     elif user_template := first_true(templates, pred=lambda t: f"/{t['id']}" == message):
         is_template = True
-        message = "{} {}".format(message, "\n".join(user_template["prompt"]))
+        message = "{} {}\n\n{}".format(message, "\n".join(user_template["prompt"]), "{{ code }}")
+
+    region = view.sel()[0]
+    lang = get_view_language_id(view, region.begin())
+    code = f"\n```{lang}\n{view.substr(region)}\n```\n"
 
     template = load_string_template(message)
-    lang = get_view_language_id(view, view.sel()[0].begin())
-    sel = [f"\n```{lang}\n{view.substr(region)}\n```\n" for region in view.sel()]
-
-    return is_template, template.render({"sel": sel})
+    return is_template, template.render({"code": code})
 
 
 def preprocess_completions(view: sublime.View, completions: list[CopilotPayloadCompletion]) -> None:

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -179,7 +179,7 @@ def prepare_completion_request(view: sublime.View, max_selections: int = 1) -> d
             "indentSize": 1,  # there is no such concept in ST
             "insertSpaces": view.settings().get("translate_tabs_to_spaces"),
             "path": file_path,
-            "uri": file_path if file_path.startswith("buffer:") else file_path and filename_to_uri(file_path),
+            "uri": file_path if file_path.startswith("buffer:") else filename_to_uri(file_path),
             "relativePath": get_project_relative_path(file_path),
             "languageId": get_view_language_id(view),
             "position": {"line": row, "character": col},
@@ -191,14 +191,14 @@ def prepare_completion_request(view: sublime.View, max_selections: int = 1) -> d
 
 
 def prepare_conversation_turn_request(
-    conv_id, id, msg, view: sublime.View, source: Literal["panel", "inline"] = "panel"
+    conversation_id: int, window_id: int, message: str, view: sublime.View, source: Literal["panel", "inline"] = "panel"
 ) -> dict[str, Any] | None:
     if not (initial_doc := prepare_completion_request(view, max_selections=5)):
         return None
     turn = {
-        "conversationId": conv_id,
-        "message": msg,
-        "workDoneToken": f"copilot_chat://{id}",
+        "conversationId": conversation_id,
+        "message: int: int: str": message,
+        "workDoneToken": f"copilot_chat://{window_id}",
         "doc": initial_doc["doc"],
         "computeSuggestions": True,
         "references": [],
@@ -220,7 +220,7 @@ def prepare_conversation_turn_request(
         turn["references"].append({
             "type": "file",
             "status": "included",
-            "uri": file_path if file_path.startswith("buffer:") else file_path and filename_to_uri(file_path),
+            "uri": file_path if file_path.startswith("buffer:") else filename_to_uri(file_path),
             "range": initial_doc["doc"]["position"],
             "visibleRange": {
                 "start": {"line": visible_start[0], "character": visible_start[1]},

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -197,7 +197,7 @@ def prepare_conversation_turn_request(
         return None
     turn = {
         "conversationId": conversation_id,
-        "message: int: int: str": message,
+        "message:": message,
         "workDoneToken": f"copilot_chat://{window_id}",
         "doc": initial_doc["doc"],
         "computeSuggestions": True,

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -225,9 +225,10 @@ def preprocess_chat_message(
         is_template = True
         message += " {{ sel[0] }}"
     elif message in user_templates:
-        is_template = True
-        template = next(filter(lambda t: f"/{t['id']}" == message, templates), None)
-        message = "{} {}".format(message, "\n".join(template["prompt"]))
+        user_template = next(filter(lambda t: f"/{t['id']}" == message, templates), None)
+        if user_template:
+            is_template = True
+            message = "{} {}".format(message, "\n".join(user_template["prompt"]))
     else:
         is_template = False
 

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -224,15 +224,13 @@ def preprocess_chat_message(
     from .template import load_string_template
 
     is_template = False
-    user_templates = [f'/{template["id"]}' for template in templates]
 
     if enum_has_value(CopilotConversationTemplates, message):
         is_template = True
         message += " {{ sel[0] }}"
-    elif message in user_templates:
-        if user_template := first_true(templates, pred=lambda t: f"/{t['id']}" == message):
-            is_template = True
-            message = "{} {}".format(message, "\n".join(user_template["prompt"]))
+    elif user_template := first_true(templates, pred=lambda t: f"/{t['id']}" == message):
+        is_template = True
+        message = "{} {}".format(message, "\n".join(user_template["prompt"]))
 
     template = load_string_template(message)
     lang = get_view_language_id(view, view.sel()[0].begin())

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -216,16 +216,18 @@ def preprocess_message_for_html(message: str) -> str:
 
 
 def preprocess_chat_message(
-    view: sublime.View, message: str, templates: dict[str, CopilotUserDefinedPromptTemplates] = {}
+    view: sublime.View, message: str, templates: list[CopilotUserDefinedPromptTemplates] = []
 ) -> tuple[bool, str]:
     from .template import load_string_template
 
+    user_templates = [f'/{template["id"]}' for template in templates]
     if message in CopilotConversationTemplates:
         is_template = True
         message += " {{ sel[0] }}"
-    elif message in templates:
+    elif message in user_templates:
         is_template = True
-        message = "{} {}".format(message, "\n".join(templates[message]["prompt"]))
+        template = next(filter(lambda t: f"/{t['id']}" == message, templates), None)
+        message = "{} {}".format(message, "\n".join(template["prompt"]))
     else:
         is_template = False
 

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -20,6 +20,7 @@ from .settings import get_plugin_setting_dotted
 from .types import (
     CopilotPayloadCompletion,
     CopilotPayloadPanelSolution,
+    CopilotRequestCoversationTurn,
     CopilotUserDefinedPromptTemplates,
 )
 from .utils import (
@@ -191,11 +192,15 @@ def prepare_completion_request(view: sublime.View, max_selections: int = 1) -> d
 
 
 def prepare_conversation_turn_request(
-    conversation_id: str, window_id: int, message: str, view: sublime.View, source: Literal["panel", "inline"] = "panel"
-) -> dict[str, Any] | None:
+    conversation_id: str,
+    window_id: int,
+    message: str,
+    view: sublime.View,
+    source: Literal["panel", "inline"] = "panel",
+) -> CopilotRequestCoversationTurn | None:
     if not (initial_doc := prepare_completion_request(view, max_selections=5)):
         return None
-    turn = {
+    turn: CopilotRequestCoversationTurn = {
         "conversationId": conversation_id,
         "message": message,
         "workDoneToken": f"copilot_chat://{window_id}",

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -197,7 +197,7 @@ def prepare_conversation_turn_request(
         return None
     turn = {
         "conversationId": conversation_id,
-        "message:": message,
+        "message": message,
         "workDoneToken": f"copilot_chat://{window_id}",
         "doc": initial_doc["doc"],
         "computeSuggestions": True,
@@ -271,7 +271,6 @@ def preprocess_chat_message(
     if user_template:
         is_template = True
         message += "\n\n{{ user_prompt }}\n\n{{ code }}"
-        message += "\n\n{{ user_prompt }}\n\n"
     else:
         return False, message
 

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -191,7 +191,7 @@ def prepare_completion_request(view: sublime.View, max_selections: int = 1) -> d
 
 
 def prepare_conversation_turn_request(
-    conversation_id: int, window_id: int, message: str, view: sublime.View, source: Literal["panel", "inline"] = "panel"
+    conversation_id: str, window_id: int, message: str, view: sublime.View, source: Literal["panel", "inline"] = "panel"
 ) -> dict[str, Any] | None:
     if not (initial_doc := prepare_completion_request(view, max_selections=5)):
         return None

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -216,7 +216,7 @@ def preprocess_message_for_html(message: str) -> str:
 
 
 def preprocess_chat_message(
-    view: sublime.View, message: str, templates: dict[CopilotUserDefinedPromptTemplates] = {}
+    view: sublime.View, message: str, templates: dict[str, CopilotUserDefinedPromptTemplates] = {}
 ) -> tuple[bool, str]:
     from .template import load_string_template
 

--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -219,7 +219,8 @@ def preprocess_chat_message(
     view: sublime.View, message: str, templates: list[CopilotUserDefinedPromptTemplates] = []
 ) -> tuple[bool, str]:
     from .template import load_string_template
-
+    
+    is_template = False
     user_templates = [f'/{template["id"]}' for template in templates]
     if message in CopilotConversationTemplates:
         is_template = True
@@ -229,8 +230,6 @@ def preprocess_chat_message(
         if user_template:
             is_template = True
             message = "{} {}".format(message, "\n".join(user_template["prompt"]))
-    else:
-        is_template = False
 
     template = load_string_template(message)
     lang = get_view_language_id(view, view.sel()[0].begin())

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -186,6 +186,10 @@ class CopilotRequestCoversationAgent(TypedDict, total=True):
     description: str
 
 
+class CopilotPayloadConversationPreconditions(TypedDict, total=True):
+    pass
+
+
 class CopilotPayloadConversationContext(TypedDict, total=True):
     conversationId: str
     """E.g., `"e3b0d5e3-0c3b-4292-a5ea-15d6003e7c45"`."""

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -185,3 +185,8 @@ class CopilotPayloadConversationContext(TypedDict, total=True):
 
 
 CopilotConversationTemplates = {"/fix", "/tests", "/doc", "/explain", "/simplify"}
+
+
+class CopilotUserDefinedPromptTemplates(TypedDict, total=True):
+    title: str
+    prompt: list[str]

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -37,6 +37,34 @@ class NetworkProxy(TypedDict, total=True):
     rejectUnauthorized: bool
 
 
+# ------------------- #
+# basic Copilot types #
+# ------------------- #
+
+
+class CopilotPositionType(TypedDict, total=True):
+    character: int
+    line: int
+
+
+class CopilotRangeType(TypedDict, total=True):
+    start: CopilotPositionType
+    end: CopilotPositionType
+
+
+class CopilotDocType(TypedDict, total=True):
+    source: str
+    tabSize: int
+    indentSize: int
+    insertSpaces: bool
+    path: str
+    uri: str
+    relativePath: str
+    languageId: str
+    position: CopilotPositionType
+    version: int
+
+
 # --------------- #
 # Copilot payload #
 # --------------- #
@@ -46,21 +74,11 @@ class CopilotPayloadFileStatus(TypedDict, total=True):
     status: Literal["not included", "included"]
 
 
-class CopilotPayloadCompletionPosition(TypedDict, total=True):
-    character: int
-    line: int
-
-
-class CopilotPayloadCompletionRange(TypedDict, total=True):
-    start: CopilotPayloadCompletionPosition
-    end: CopilotPayloadCompletionPosition
-
-
 class CopilotPayloadCompletion(TypedDict, total=True):
     text: str
-    position: CopilotPayloadCompletionPosition
+    position: CopilotPositionType
     uuid: str
-    range: CopilotPayloadCompletionRange
+    range: CopilotRangeType
     displayText: str
     point: StPoint
     region: StRegion
@@ -133,7 +151,7 @@ class CopilotPayloadPanelSolution(TypedDict, total=True):
     score: int
     panelId: str
     completionText: str
-    range: CopilotPayloadCompletionRange
+    range: CopilotRangeType
     region: StRegion
 
 
@@ -178,6 +196,25 @@ class CopilotPayloadConversationTemplate(TypedDict, total=True):
     description: str
     shortDescription: str
     scopes: list[str]
+
+
+class CopilotRequestCoversationTurn(TypedDict, total=True):
+    conversationId: str
+    message: str
+    workDoneToken: str
+    doc: CopilotDocType
+    computeSuggestions: bool
+    references: list[CopilotRequestCoversationTurnReference]
+    source: Literal["panel", "inline"]
+
+
+class CopilotRequestCoversationTurnReference(TypedDict, total=True):
+    type: str
+    status: str
+    uri: str
+    range: CopilotPositionType
+    visibleRange: CopilotRangeType
+    selection: CopilotRangeType
 
 
 class CopilotRequestCoversationAgent(TypedDict, total=True):

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -190,6 +190,13 @@ class CopilotPayloadConversationPreconditions(TypedDict, total=True):
     pass
 
 
+class CopilotPayloadConversationCreate(TypedDict, total=True):
+    conversationId: str
+    """E.g., `"15d1791c-42f4-490c-9f79-0b79c4142d17"`."""
+    turnId: str
+    """E.g., `"a4a3785f-808f-41cc-8037-cd6707ffe584"`."""
+
+
 class CopilotPayloadConversationContext(TypedDict, total=True):
     conversationId: str
     """E.g., `"e3b0d5e3-0c3b-4292-a5ea-15d6003e7c45"`."""

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Literal, Tuple, TypedDict, TypeVar
 
+from LSP.plugin.core.typing import StrEnum
+
 T_Callable = TypeVar("T_Callable", bound=Callable[..., Any])
 
 
@@ -144,6 +146,14 @@ class CopilotPayloadPanelCompletionSolutionCount(TypedDict, total=True):
 # --------------------- #
 
 
+class CopilotConversationTemplates(StrEnum):
+    FIX = "/fix"
+    TESTS = "/tests"
+    DOC = "/doc"
+    EXPLAIN = "/explain"
+    SIMPLIFY = "/simplify"
+
+
 class CopilotPayloadConversationEntry(TypedDict, total=True):
     kind: str
     conversationId: str
@@ -182,9 +192,6 @@ class CopilotPayloadConversationContext(TypedDict, total=True):
     turnId: str
     """E.g., `"09ac7601-6c28-4617-b3e4-13f5ff8502b7"`."""
     skillId: Literal["current-editor", "project-labels", "recent-files"]  # not the complet list yet
-
-
-CopilotConversationTemplates = {"/fix", "/tests", "/doc", "/explain", "/simplify"}
 
 
 class CopilotUserDefinedPromptTemplates(TypedDict, total=True):

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -188,5 +188,6 @@ CopilotConversationTemplates = {"/fix", "/tests", "/doc", "/explain", "/simplify
 
 
 class CopilotUserDefinedPromptTemplates(TypedDict, total=True):
-    title: str
+    id: str
+    description: str
     prompt: list[str]

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -191,3 +191,4 @@ class CopilotUserDefinedPromptTemplates(TypedDict, total=True):
     id: str
     description: str
     prompt: list[str]
+    scopes: list[str]

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -198,17 +198,17 @@ class CopilotPayloadConversationTemplate(TypedDict, total=True):
     scopes: list[str]
 
 
-class CopilotRequestCoversationTurn(TypedDict, total=True):
+class CopilotRequestConversationTurn(TypedDict, total=True):
     conversationId: str
     message: str
     workDoneToken: str
     doc: CopilotDocType
     computeSuggestions: bool
-    references: list[CopilotRequestCoversationTurnReference]
+    references: list[CopilotRequestConversationTurnReference]
     source: Literal["panel", "inline"]
 
 
-class CopilotRequestCoversationTurnReference(TypedDict, total=True):
+class CopilotRequestConversationTurnReference(TypedDict, total=True):
     type: str
     status: str
     uri: str
@@ -217,7 +217,7 @@ class CopilotRequestCoversationTurnReference(TypedDict, total=True):
     selection: CopilotRangeType
 
 
-class CopilotRequestCoversationAgent(TypedDict, total=True):
+class CopilotRequestConversationAgent(TypedDict, total=True):
     slug: str
     name: str
     description: str

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -6,6 +6,7 @@ import textwrap
 import threading
 import urllib.request
 from collections.abc import Callable, Generator, Iterable
+from enum import EnumMeta
 from functools import wraps
 from itertools import takewhile
 from typing import Any, TypeVar, Union, cast
@@ -87,6 +88,15 @@ def debounce(time_s: float = 0.3) -> Callable[[T_Callable], T_Callable]:
 def drop_falsy(iterable: Iterable[_T | None]) -> Generator[_T, None, None]:
     """Drops falsy values from the iterable."""
     yield from filter(None, iterable)
+
+
+def enum_has_value(enum_cls: EnumMeta, value: Any) -> bool:
+    """Check if the `enum_cls` class contains the `value`."""
+    try:
+        enum_cls(value)
+    except ValueError:
+        return False
+    return True
 
 
 def find_sheet_by_id(id: int) -> sublime.Sheet | None:

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -6,7 +6,6 @@ import textwrap
 import threading
 import urllib.request
 from collections.abc import Callable, Generator, Iterable
-from enum import EnumMeta
 from functools import wraps
 from itertools import takewhile
 from typing import Any, TypeVar, Union, cast
@@ -88,15 +87,6 @@ def debounce(time_s: float = 0.3) -> Callable[[T_Callable], T_Callable]:
 def drop_falsy(iterable: Iterable[_T | None]) -> Generator[_T, None, None]:
     """Drops falsy values from the iterable."""
     yield from filter(None, iterable)
-
-
-def enum_has_value(enum_cls: EnumMeta, value: Any) -> bool:
-    """Check if the `enum_cls` class contains the `value`."""
-    try:
-        enum_cls(value)
-    except ValueError:
-        return False
-    return True
 
 
 def find_sheet_by_id(id: int) -> sublime.Sheet | None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ markupsafe==2.1.5
     # via jinja2
 more-itertools==10.3.0
     # via -r requirements.in
-mypy==1.11.0
+mypy==1.11.1
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via mypy

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -19,6 +19,19 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
+                    "authProvider": {
+                      "default": "github",
+                      "markdownDescription": "The GitHub identity to use for Copilot",
+                      "type": "string",
+                      "enumDescriptions": [
+                        "GitHub.com",
+                        "GitHub Enterprise"
+                      ],
+                      "enum": [
+                        "github",
+                        "github-enterprise"
+                      ],
+                    },
                     "auto_ask_completions": {
                       "default": true,
                       "description": "Auto ask the server for completions. Otherwise, you have to trigger it manually.",
@@ -43,19 +56,6 @@
                       "markdownDescription": "Enables `debug` mode fo the LSP-copilot. Enabling all commands regardless of status requirements.",
                       "type": "boolean"
                     },
-                    "authProvider": {
-                      "default": "github",
-                      "markdownDescription": "The GitHub identity to use for Copilot",
-                      "type": "string",
-                      "enumDescriptions": [
-                        "GitHub.com",
-                        "GitHub Enterprise"
-                      ],
-                      "enum": [
-                        "github",
-                        "github-enterprise"
-                      ],
-                    },
                     "github-enterprise": {
                       "type": "object",
                       "markdownDescription": "The configuration for Github Enterprise.",
@@ -77,20 +77,38 @@
                       "description": "Enables local checks. This feature is not fully understood yet.",
                       "type": "boolean"
                     },
+                    "prompts": {
+                      "default": true,
+                      "markdownDescription": "Enables custom user prompts for Copilot completions.",
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "markdownDescription": "Title of the prompt.",
+                          "type": "string"
+                        },
+                        "prompt": {
+                          "markdownDescription": "The prompt message.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "proxy": {
                       "default": "",
                       "markdownDescription": "The HTTP proxy to use for Copilot requests. It's in the form of `username:password@host:port` or just `host:port`.",
+                      "type": "string"
+                    },
+                    "status_text": {
+                      "default": "{% if server_version %}v{{ server_version }}{% endif %}",
+                      "markdownDescription": "The (Jinja2) template of the status bar text which is inside the parentheses `(...)`. See https://jinja.palletsprojects.com/templates/",
                       "type": "string"
                     },
                     "telemetry": {
                       "default": false,
                       "markdownDescription": "Enables Copilot telemetry requests for `Accept` and `Reject` completions.",
                       "type": "boolean"
-                    },
-                    "status_text": {
-                      "default": "{% if server_version %}v{{ server_version }}{% endif %}",
-                      "markdownDescription": "The (Jinja2) template of the status bar text which is inside the parentheses `(...)`. See https://jinja.palletsprojects.com/templates/",
-                      "type": "string"
                     }
                   }
                 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -80,17 +80,24 @@
                     "prompts": {
                       "default": true,
                       "markdownDescription": "Enables custom user prompts for Copilot completions.",
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "markdownDescription": "Title of the prompt.",
-                          "type": "string"
-                        },
-                        "prompt": {
-                          "markdownDescription": "The prompt message.",
-                          "type": "array",
-                          "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "markdownDescription": "The ID of the prompt that acts as the trigger. `/` is automatically assumed and shouldn't be included.",
                             "type": "string"
+                          },
+                          "description": {
+                            "markdownDescription": "The description of the prompt.",
+                            "type": "string"
+                          },
+                          "prompt": {
+                            "markdownDescription": "The prompt message.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
Copilot uses GPT in the background. Essentially meaning you can create prompts in the chat panel. This just allows users to add re-usable prompts that can be triggered by the same logic as the build in prompts




