### PR TITLE
fix: `/explain` (and others) doesn't work

### DIFF
--- a/plugin/helpers.py
+++ b/plugin/helpers.py
@@ -20,6 +20,7 @@ from .constants import COPILOT_WINDOW_SETTINGS_PREFIX, PACKAGE_NAME
 from .log import log_error
 from .settings import get_plugin_setting_dotted
 from .types import (
+    CopilotConversationTemplates,
     CopilotDocType,
     CopilotPayloadCompletion,
     CopilotPayloadPanelSolution,
@@ -284,10 +285,8 @@ def preprocess_chat_message(
 
     templates = templates or []
     user_template = first_true(templates, pred=lambda t: f"/{t['id']}" == message)
-    is_template = False
 
-    if user_template:
-        is_template = True
+    if is_template := bool(user_template or CopilotConversationTemplates.has_value(message)):
         message += "\n\n{{ user_prompt }}\n\n{{ code }}"
 
     region = view.sel()[0]

--- a/plugin/types.py
+++ b/plugin/types.py
@@ -163,6 +163,14 @@ class CopilotConversationTemplates(StrEnum):
     EXPLAIN = "/explain"
     SIMPLIFY = "/simplify"
 
+    @classmethod
+    def has_value(cls, value: str) -> bool:
+        try:
+            cls(value)
+            return True
+        except ValueError:
+            return False
+
 
 class CopilotPayloadConversationEntry(TypedDict, total=True):
     kind: str


### PR DESCRIPTION
because no code is provided to Copilot.

Fixes https://github.com/TerminalFi/LSP-copilot/issues/196

---

This PR will append code to the chat template if the chat msg starts with `/`.